### PR TITLE
calc remaining path instead of distance travelled

### DIFF
--- a/src/scenes/levels/SeanMap.tscn
+++ b/src/scenes/levels/SeanMap.tscn
@@ -268,6 +268,7 @@ polygons = [ PoolIntArray( 0, 1, 2, 3 ) ]
 
 [node name="SeanMap" type="Node2D"]
 script = ExtResource( 13 )
+
 income_per_wave = 75
 income_per_kill = 10
 wave_1 = [ "Wave 1", 20, 0, 0, 1.0 ]
@@ -316,7 +317,7 @@ position = Vector2( 1600, -91 )
 [node name="Towers" type="Node2D" parent="."]
 
 [node name="ExitPoint" type="Position2D" parent="."]
-position = Vector2( 1698, 1119 )
+position = Vector2( 1568, 1120 )
 
 [node name="DamageZone" type="Area2D" parent="ExitPoint"]
 

--- a/src/scripts/TowersGeneral.gd
+++ b/src/scripts/TowersGeneral.gd
@@ -55,8 +55,8 @@ func select_enemy(select_mode):
 	for i in enemy_array:
 		var path_distance = i.get_distance()
 		enemy_progress_array.append(path_distance)
-	var max_offset = enemy_progress_array.max()
-	var enemy_index = enemy_progress_array.find(max_offset)
+	var min_offset = enemy_progress_array.min()
+	var enemy_index = enemy_progress_array.find(min_offset)
 	if enemy != enemy_array[enemy_index]:
 		for n in $FacingDirection/BulletContainer.get_children():
 			n.free()

--- a/src/scripts/test_enemies_general.gd
+++ b/src/scripts/test_enemies_general.gd
@@ -6,7 +6,11 @@ var distance_travelled = 0
 var health
 var health_perc
 var type = "enemy"
+var remaining_dist = 0
+
 onready var game_scene = get_node("../../..")
+
+var sean_test = true
 
 func _ready():
 	$HealthBar.value = self.max_health
@@ -18,7 +22,9 @@ func _ready():
 	
 func _physics_process(delta):
 	distance_travelled = distance_travelled+self.speed
+	
 	if path.size() > 0:
+		calc_remaining_dist()
 		var target = global_position.direction_to(path[0])
 		velocity = move_and_slide(target * self.speed) * delta
 		var path_distance = global_position.distance_to(path[0])
@@ -35,6 +41,21 @@ func calculate_health_perc():
 #	var perc = (health/self.max_health)*100
 	var perc = round((float(health)/self.max_health)* 100)
 	health_perc = perc
+	
+
+func calc_remaining_dist():
+	var temp_dist
+	var curr_index = 0
+	temp_dist = global_position.distance_to(path[0])
+	
+	for i in path:
+		curr_index = curr_index+1
+		if curr_index != path.size():
+			var distance = i.distance_to(path[curr_index])
+			temp_dist = temp_dist+distance
+	
+	remaining_dist=temp_dist
+
 func set_health_tint():
 	if health_perc == 100:
 		$HealthBar.visible = false
@@ -50,7 +71,7 @@ func set_health_tint():
 		$HealthBar.visible = false
 	
 func get_distance():
-	return distance_travelled
+	return remaining_dist
 
 func take_damage(damage):
 	health = health-damage


### PR DESCRIPTION
once i introduced more than one path, with different lengths, the way I was calculating what enemy to aim at for a given tower became flawed. I was using 'distance travelled' but this meant that creatures who were further from the end, but from the longer path, got prioritised over enemies who were about to leak from the shorter path.

To fix this, I had to determine the distance between each of the vector2s in the path array, sum the distances and add the players distance from the first point. This now counts down to 0 as they get closer to their final goal. Swapped targetting to aim for the enemy with the lowest 'remaining distance' and it works as desired from testing.